### PR TITLE
fix: harden freecam clamp, collision, and fullbright

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Camera hitbox is below .5 blocks so it can even fit under a top slab and in the 
 Tripod system - Saved camera positions by holding the toggle key and pressing a number key  
 4 collision modes: Full, Ignore Transparent (non-opaque blocks including openables), Ignore Openables (doors, trapdoors, etc) and None (noclip)  
 Config options for fullbright, fog removal, hand rendering, and initial perspective  
+Camera is clamped to a sphere inside the player's render distance
 Server owners can include the mod to force the collision mode or to disable the mod entirely for players  
 The server must have the mod if the client has the mod. Mod is optional if server has the mod
 

--- a/src/main/java/com/caedis/freecam/camera/CameraEntity.java
+++ b/src/main/java/com/caedis/freecam/camera/CameraEntity.java
@@ -28,6 +28,9 @@ public class CameraEntity extends EntityPlayer {
     @Setter
     private GeneralConfig.CollisionMode collisionMode = GeneralConfig.CollisionMode.FULL;
 
+    // Reused across collision sub-steps so fast movement doesn't allocate a list per step.
+    private final List<AxisAlignedBB> collisionScratch = new ArrayList<>();
+
     public CameraEntity(World world, EntityPlayer player) {
         super(world, CAMERA_PROFILE);
         setSize(0.4F, 0.425F);
@@ -81,12 +84,35 @@ public class CameraEntity extends EntityPlayer {
         prevRotationYawHead = rotationYawHead;
     }
 
+    // Max distance moved per collision sub-step. Smaller than the hitbox so a fast camera cannot
+    // tunnel or peek through a thin block in a single tick.
+    private static final double MAX_STEP = 0.2D;
+    // Upper bound on sub-steps to avoid huge collision scans on extreme deltas (e.g. teleports).
+    private static final int MAX_STEPS = 64;
+
     @Override
     public void moveEntity(double dx, double dy, double dz) {
         if (collisionMode == GeneralConfig.CollisionMode.NONE) {
             noClip = true;
             setPosition(posX + dx, posY + dy, posZ + dz);
-        } else if (collisionMode == GeneralConfig.CollisionMode.FULL) {
+            return;
+        }
+
+        // Split large movements so swept collision resolves in small increments instead of letting
+        // a fast camera stop flush inside/through thin geometry.
+        double dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        int steps = dist > MAX_STEP ? Math.min(MAX_STEPS, (int) Math.ceil(dist / MAX_STEP)) : 1;
+        double sx = dx / steps;
+        double sy = dy / steps;
+        double sz = dz / steps;
+
+        for (int i = 0; i < steps; i++) {
+            moveStep(sx, sy, sz);
+        }
+    }
+
+    private void moveStep(double dx, double dy, double dz) {
+        if (collisionMode == GeneralConfig.CollisionMode.FULL) {
             noClip = false;
             super.moveEntity(dx, dy, dz);
             // Fix posY: super derives it as bb.minY + yOffset - ySize, but we want bb center
@@ -129,7 +155,8 @@ public class CameraEntity extends EntityPlayer {
     }
 
     private List<AxisAlignedBB> getFilteredCollisionBoxes(AxisAlignedBB area) {
-        List<AxisAlignedBB> result = new ArrayList<>();
+        List<AxisAlignedBB> result = collisionScratch;
+        result.clear();
 
         int minX = MathHelper.floor_double(area.minX);
         int maxX = MathHelper.floor_double(area.maxX + 1.0D);

--- a/src/main/java/com/caedis/freecam/camera/FreecamController.java
+++ b/src/main/java/com/caedis/freecam/camera/FreecamController.java
@@ -32,7 +32,6 @@ public class FreecamController {
     private TripodSlot activeSlot = TripodSlot.NONE;
     private boolean pendingDisable;
     private int previousPerspective = -1;
-    private float previousGamma = -1f;
     private float speedMultiplier = 1.0F;
 
     private static final float SPEED_SCROLL_STEP = 0.1F;
@@ -117,10 +116,6 @@ public class FreecamController {
         previousRenderViewEntity = mc.renderViewEntity;
         previousPerspective = mc.gameSettings.thirdPersonView;
         mc.gameSettings.thirdPersonView = 0;
-        if (MiscConfig.fullBright) {
-            previousGamma = mc.gameSettings.gammaSetting;
-            mc.gameSettings.gammaSetting = 100f;
-        }
         mc.renderViewEntity = cameraEntity;
         active = true;
         playerControlled = false;
@@ -141,10 +136,6 @@ public class FreecamController {
         if (previousPerspective == -1) {
             previousPerspective = mc.gameSettings.thirdPersonView;
             mc.gameSettings.thirdPersonView = 0;
-        }
-        if (previousGamma == -1f && MiscConfig.fullBright) {
-            previousGamma = mc.gameSettings.gammaSetting;
-            mc.gameSettings.gammaSetting = 100f;
         }
         mc.renderViewEntity = cameraEntity;
         active = true;
@@ -171,10 +162,6 @@ public class FreecamController {
         mc.renderViewEntity = previousRenderViewEntity;
         mc.gameSettings.thirdPersonView = previousPerspective;
         previousPerspective = -1;
-        if (previousGamma != -1f) {
-            mc.gameSettings.gammaSetting = previousGamma;
-            previousGamma = -1;
-        }
         previousRenderViewEntity = null;
         cameraEntity = null;
         active = false;
@@ -183,6 +170,10 @@ public class FreecamController {
 
     private static final double THIRD_PERSON_DISTANCE = 4.0;
     private static final double FIRST_PERSON_DISTANCE = 0.4;
+
+    // Chunks to subtract from render distance when clamping the camera. Higher = more aggressive,
+    // keeps the camera further from the border where ore could be xrayed.
+    private static final int CLAMP_MARGIN_CHUNKS = 2;
 
     // main logic from orientCamera
     private void applyPerspectiveOffset() {
@@ -307,15 +298,21 @@ public class FreecamController {
     private void clampToRenderDistance() {
         if (mc.thePlayer == null) return;
 
-        double maxDist = (mc.gameSettings.renderDistanceChunks - 1) * 16.0;
+        // Stay well inside the render distance edge
+        double maxDist = (mc.gameSettings.renderDistanceChunks - CLAMP_MARGIN_CHUNKS) * 16.0;
+        if (maxDist < 0) maxDist = 0;
+
         double dx = cameraEntity.posX - mc.thePlayer.posX;
+        double dy = cameraEntity.posY - mc.thePlayer.posY;
         double dz = cameraEntity.posZ - mc.thePlayer.posZ;
 
-        double clampedX = Math.max(-maxDist, Math.min(maxDist, dx));
-        double clampedZ = Math.max(-maxDist, Math.min(maxDist, dz));
-
-        if (clampedX != dx || clampedZ != dz) {
-            cameraEntity.setPosition(mc.thePlayer.posX + clampedX, cameraEntity.posY, mc.thePlayer.posZ + clampedZ);
+        // Radial (spherical) clamp on all three axes. Move via moveEntity (not setPosition) so the
+        // correction is collision-aware and never stuffs the camera into a block when the player
+        // walks away from a tripod.
+        double distSq = dx * dx + dy * dy + dz * dz;
+        if (distSq > maxDist * maxDist) {
+            double scale = maxDist / Math.sqrt(distSq);
+            cameraEntity.moveEntity(dx * (scale - 1), dy * (scale - 1), dz * (scale - 1));
         }
     }
 

--- a/src/main/java/com/caedis/freecam/mixins/early/minecraft/MixinEntityRenderer.java
+++ b/src/main/java/com/caedis/freecam/mixins/early/minecraft/MixinEntityRenderer.java
@@ -6,10 +6,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -60,6 +62,22 @@ public class MixinEntityRenderer {
             }
             ci.cancel();
         }
+    }
+
+    @Redirect(
+        method = "updateLightmap",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/client/settings/GameSettings;gammaSetting:F",
+            opcode = Opcodes.GETFIELD))
+    private float freecam$fullbrightGamma(GameSettings settings) {
+        // Apply fullbright at render time instead of mutating the persistent gammaSetting, so a
+        // force-quit while in freecam cannot leave the saved gamma stuck on full bright.
+        if (FreecamController.instance()
+            .isActive() && MiscConfig.fullBright) {
+            return 100.0F;
+        }
+        return settings.gammaSetting;
     }
 
     @Inject(method = "renderHand", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
Sphere clamp around the player instead of box clamp.
Fullbright is now mixin applied instead of changing the player's gamma.
Collision is now resolved in sub checks to further prevent near plane clipping.