### PR TITLE
Body lock&fix/jetpacks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,11 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Controlling:2.1.7:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:HoloInventory:2.5.15-GTNH:dev")
+    compileOnly("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.139-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:Galacticraft:3.3.5-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.20:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ProjectRed:4.12.39-GTNH:dev") { transitive = false }
 
 
     devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.31:dev")

--- a/src/main/java/com/caedis/freecam/camera/FreecamController.java
+++ b/src/main/java/com/caedis/freecam/camera/FreecamController.java
@@ -5,8 +5,6 @@ import net.minecraft.client.settings.GameSettings;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.StatCollector;
 
-import org.lwjgl.input.Keyboard;
-
 import com.caedis.freecam.camera.tripod.TripodRegistry;
 import com.caedis.freecam.camera.tripod.TripodSlot;
 import com.caedis.freecam.config.GeneralConfig;
@@ -32,11 +30,11 @@ public class FreecamController {
     private TripodSlot activeSlot = TripodSlot.NONE;
     private boolean pendingDisable;
     private int previousPerspective = -1;
-    private float speedMultiplier = 1.0F;
+    private float speedMultiplier = 2.0F;
 
     private static final float SPEED_SCROLL_STEP = 0.1F;
     private static final float SPEED_MULTIPLIER_MIN = 0.1F;
-    private static final float SPEED_MULTIPLIER_MAX = 10.0F;
+    private static final float SPEED_MULTIPLIER_MAX = 20.0F;
 
     private double velocityX;
     private double velocityY;
@@ -235,10 +233,15 @@ public class FreecamController {
     }
 
     public void adjustSpeed(int scrollDelta) {
+        float step = SPEED_SCROLL_STEP;
+        if (GameSettings.isKeyDown(mc.gameSettings.keyBindSprint)) {
+            step *= 10.0F;
+        }
+
         if (scrollDelta > 0) {
-            speedMultiplier = Math.min(SPEED_MULTIPLIER_MAX, speedMultiplier + SPEED_SCROLL_STEP);
+            speedMultiplier = Math.min(SPEED_MULTIPLIER_MAX, speedMultiplier + step);
         } else if (scrollDelta < 0) {
-            speedMultiplier = Math.max(SPEED_MULTIPLIER_MIN, speedMultiplier - SPEED_SCROLL_STEP);
+            speedMultiplier = Math.max(SPEED_MULTIPLIER_MIN, speedMultiplier - step);
         }
         speedMultiplier = Math.round(speedMultiplier * 10.0F) / 10.0F;
 
@@ -273,13 +276,13 @@ public class FreecamController {
         if (playerControlled) return;
 
         GameSettings gs = mc.gameSettings;
-        boolean forward = Keyboard.isKeyDown(gs.keyBindForward.getKeyCode());
-        boolean back = Keyboard.isKeyDown(gs.keyBindBack.getKeyCode());
-        boolean left = Keyboard.isKeyDown(gs.keyBindLeft.getKeyCode());
-        boolean right = Keyboard.isKeyDown(gs.keyBindRight.getKeyCode());
-        boolean up = Keyboard.isKeyDown(gs.keyBindJump.getKeyCode());
-        boolean down = Keyboard.isKeyDown(gs.keyBindSneak.getKeyCode());
-        boolean sprint = Keyboard.isKeyDown(gs.keyBindSprint.getKeyCode());
+        boolean forward = GameSettings.isKeyDown(gs.keyBindForward);
+        boolean back = GameSettings.isKeyDown(gs.keyBindBack);
+        boolean left = GameSettings.isKeyDown(gs.keyBindLeft);
+        boolean right = GameSettings.isKeyDown(gs.keyBindRight);
+        boolean up = GameSettings.isKeyDown(gs.keyBindJump);
+        boolean down = GameSettings.isKeyDown(gs.keyBindSneak);
+        boolean sprint = GameSettings.isKeyDown(gs.keyBindSprint);
 
         double speed = MovementConfig.speed * speedMultiplier;
         if (sprint) {

--- a/src/main/java/com/caedis/freecam/config/MovementConfig.java
+++ b/src/main/java/com/caedis/freecam/config/MovementConfig.java
@@ -15,6 +15,10 @@ public class MovementConfig {
     @Config.DefaultEnum("CREATIVE")
     public static MovementMode movementMode;
 
+    @Config.Comment("Lock the player's body in place while in freecam (prevents movement from external forces)")
+    @Config.DefaultBoolean(false)
+    public static boolean lockPlayerBody;
+
     public enum MovementMode {
         CREATIVE,
         STATIC

--- a/src/main/java/com/caedis/freecam/mixins/Mixins.java
+++ b/src/main/java/com/caedis/freecam/mixins/Mixins.java
@@ -26,7 +26,23 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     HOLOINVENTORY(new MixinBuilder().setPhase(Phase.LATE)
         .addClientMixins("holoinventory.MixinRenderer")
-        .addRequiredMod(TargetedMod.HOLOINVENTORY));
+        .addRequiredMod(TargetedMod.HOLOINVENTORY)),
+    IC2(new MixinBuilder().setPhase(Phase.LATE)
+        .addClientMixins("ic2.MixinIC2Keyboard")
+        .addRequiredMod(TargetedMod.IC2)),
+    GALAXYSPACE(new MixinBuilder().setPhase(Phase.LATE)
+        .addClientMixins(
+            "galaxyspace.MixinGalaxySpaceKeyHandler$MixinItemJetPack",
+            "galaxyspace.MixinGalaxySpaceKeyHandler$MixinItemSpacesuitJetPlate",
+            "galaxyspace.MixinGalaxySpaceParticles$MixinEntityJetpackFlameFX",
+            "galaxyspace.MixinGalaxySpaceParticles$MixinEntityJetpackSmokeFX")
+        .addRequiredMod(TargetedMod.GALAXYSPACE)),
+    GREGTECH(new MixinBuilder().setPhase(Phase.LATE)
+        .addClientMixins("gregtech.MixinGregTechJetpack")
+        .addRequiredMod(TargetedMod.GREGTECH)),
+    PROJECTRED(new MixinBuilder().setPhase(Phase.LATE)
+        .addClientMixins("projectred.MixinProjectRedJetpack")
+        .addRequiredMod(TargetedMod.PROJECTRED));
     // spotless:on
 
     private final MixinBuilder builder;

--- a/src/main/java/com/caedis/freecam/mixins/TargetedMod.java
+++ b/src/main/java/com/caedis/freecam/mixins/TargetedMod.java
@@ -9,7 +9,11 @@ public enum TargetedMod implements ITargetMod {
 
     WAILA(null, "Waila"),
     THAUMCRAFT(null, "Thaumcraft"),
-    HOLOINVENTORY(null, "holoinventory");
+    HOLOINVENTORY(null, "holoinventory"),
+    IC2("ic2.core.IC2", "IC2"),
+    GALAXYSPACE("galaxyspace.core.GSCore", "GalaxySpace"),
+    GREGTECH("gregtech.GT_Mod", "gregtech"),
+    PROJECTRED("mrtjp.projectred.ProjectRedExpansion", "ProjRed|Expansion");
 
     private final TargetModBuilder builder;
 

--- a/src/main/java/com/caedis/freecam/mixins/early/minecraft/MixinEntityLivingBase.java
+++ b/src/main/java/com/caedis/freecam/mixins/early/minecraft/MixinEntityLivingBase.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.caedis.freecam.camera.FreecamController;
 import com.caedis.freecam.config.GeneralConfig;
+import com.caedis.freecam.config.MovementConfig;
 
 @Mixin(EntityLivingBase.class)
 public abstract class MixinEntityLivingBase {
@@ -26,6 +27,14 @@ public abstract class MixinEntityLivingBase {
                 FreecamController.instance()
                     .scheduleDisable();
             }
+        }
+    }
+
+    @Inject(method = "moveEntityWithHeading", at = @At("HEAD"), cancellable = true)
+    private void freecam$cancelMovement(float strafe, float forward, CallbackInfo ci) {
+        if (MovementConfig.lockPlayerBody && FreecamController.instance()
+            .isActive() && this.equals(Minecraft.getMinecraft().thePlayer)) {
+            ci.cancel();
         }
     }
 }

--- a/src/main/java/com/caedis/freecam/mixins/late/galaxyspace/MixinGalaxySpaceKeyHandler.java
+++ b/src/main/java/com/caedis/freecam/mixins/late/galaxyspace/MixinGalaxySpaceKeyHandler.java
@@ -1,0 +1,91 @@
+package com.caedis.freecam.mixins.late.galaxyspace;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.caedis.freecam.camera.FreecamController;
+
+import galaxyspace.core.item.armor.ItemJetPack;
+import galaxyspace.core.item.armor.ItemSpacesuitJetPlate;
+
+/**
+ * Mixin to disable GalaxySpace jetpack controls during freecam. Targets both standalone jetpack and spacesuit with
+ * integrated jetpack.
+ */
+public class MixinGalaxySpaceKeyHandler {
+
+    /**
+     * Mixin for standalone jetpack item
+     */
+    @Mixin(value = ItemJetPack.class, remap = false)
+    public static abstract class MixinItemJetPack {
+
+        @Inject(method = "useJetpack", at = @At("HEAD"), cancellable = true, remap = false)
+        private void disableJetpackInFreecam(EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+            FreecamController controller = FreecamController.instance();
+            if (controller.isActive() && !controller.isPlayerControlled()) {
+                cir.setReturnValue(false);
+            }
+        }
+
+        @Inject(method = "onArmorTick", at = @At("HEAD"), cancellable = true, remap = false)
+        private void cancelArmorTickInFreecam(World world, EntityPlayer player, ItemStack itemStack, CallbackInfo ci) {
+            FreecamController controller = FreecamController.instance();
+            if (controller.isActive() && !controller.isPlayerControlled()) {
+                ci.cancel();
+            }
+        }
+
+        /**
+         * Cancel the use() method which spawns particles
+         */
+        @Inject(method = "use", at = @At("HEAD"), cancellable = true, remap = false)
+        private void cancelUseInFreecam(ItemStack itemStack, double acceleration, CallbackInfo ci) {
+            FreecamController controller = FreecamController.instance();
+            if (controller.isActive() && !controller.isPlayerControlled()) {
+                ci.cancel();
+            }
+        }
+    }
+
+    /**
+     * Mixin for spacesuit chest piece with integrated jetpack (the commonly used variant)
+     */
+    @Mixin(value = ItemSpacesuitJetPlate.class, remap = false)
+    public static abstract class MixinItemSpacesuitJetPlate {
+
+        @Inject(method = "useJetpack", at = @At("HEAD"), cancellable = true, remap = false)
+        private void disableJetpackInFreecam(EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+            FreecamController controller = FreecamController.instance();
+            if (controller.isActive() && !controller.isPlayerControlled()) {
+                cir.setReturnValue(false);
+            }
+        }
+
+        @Inject(method = "onArmorTick", at = @At("HEAD"), cancellable = true, remap = false)
+        private void cancelArmorTickInFreecam(World world, EntityPlayer player, ItemStack itemStack, CallbackInfo ci) {
+            FreecamController controller = FreecamController.instance();
+            if (controller.isActive() && !controller.isPlayerControlled()) {
+                ci.cancel();
+            }
+        }
+
+        /**
+         * Cancel the use() method which spawns particles
+         */
+        @Inject(method = "use", at = @At("HEAD"), cancellable = true, remap = false)
+        private void cancelUseInFreecam(ItemStack itemStack, double acceleration, CallbackInfo ci) {
+            FreecamController controller = FreecamController.instance();
+            if (controller.isActive() && !controller.isPlayerControlled()) {
+                ci.cancel();
+            }
+        }
+    }
+}

--- a/src/main/java/com/caedis/freecam/mixins/late/galaxyspace/MixinGalaxySpaceKeyHandler.java
+++ b/src/main/java/com/caedis/freecam/mixins/late/galaxyspace/MixinGalaxySpaceKeyHandler.java
@@ -8,9 +8,9 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.caedis.freecam.camera.FreecamController;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 
 import galaxyspace.core.item.armor.ItemJetPack;
 import galaxyspace.core.item.armor.ItemSpacesuitJetPlate;
@@ -27,12 +27,13 @@ public class MixinGalaxySpaceKeyHandler {
     @Mixin(value = ItemJetPack.class, remap = false)
     public static abstract class MixinItemJetPack {
 
-        @Inject(method = "useJetpack", at = @At("HEAD"), cancellable = true, remap = false)
-        private void disableJetpackInFreecam(EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+        @ModifyReturnValue(method = "useJetpack", at = @At("RETURN"), remap = false)
+        private boolean disableJetpackInFreecam(boolean original, EntityPlayer player) {
             FreecamController controller = FreecamController.instance();
             if (controller.isActive() && !controller.isPlayerControlled()) {
-                cir.setReturnValue(false);
+                return false;
             }
+            return original;
         }
 
         @Inject(method = "onArmorTick", at = @At("HEAD"), cancellable = true, remap = false)
@@ -61,12 +62,13 @@ public class MixinGalaxySpaceKeyHandler {
     @Mixin(value = ItemSpacesuitJetPlate.class, remap = false)
     public static abstract class MixinItemSpacesuitJetPlate {
 
-        @Inject(method = "useJetpack", at = @At("HEAD"), cancellable = true, remap = false)
-        private void disableJetpackInFreecam(EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+        @ModifyReturnValue(method = "useJetpack", at = @At("RETURN"), remap = false)
+        private boolean disableJetpackInFreecam(boolean original, EntityPlayer player) {
             FreecamController controller = FreecamController.instance();
             if (controller.isActive() && !controller.isPlayerControlled()) {
-                cir.setReturnValue(false);
+                return false;
             }
+            return original;
         }
 
         @Inject(method = "onArmorTick", at = @At("HEAD"), cancellable = true, remap = false)

--- a/src/main/java/com/caedis/freecam/mixins/late/galaxyspace/MixinGalaxySpaceParticles.java
+++ b/src/main/java/com/caedis/freecam/mixins/late/galaxyspace/MixinGalaxySpaceParticles.java
@@ -18,8 +18,8 @@ import galaxyspace.core.particle.EntityJetpackSmokeFX;
 import micdoodle8.mods.galacticraft.api.vector.Vector3;
 
 /**
- * Mixin to prevent GalaxySpace jetpack particles from spawning/updating during freecam. Note: GalaxySpace 1.1.139+
- * uses Vector3 constructor instead of individual doubles.
+ * Mixin to prevent GalaxySpace jetpack particles from spawning during freecam. Particles are marked dead immediately
+ * in the constructor to avoid per-frame allocation overhead from onUpdate hooks.
  */
 public class MixinGalaxySpaceParticles {
 
@@ -48,20 +48,10 @@ public class MixinGalaxySpaceParticles {
         private void onConstructor(World world, Vector3 position, Vector3 motion, CallbackInfo ci) {
             FreecamController controller = FreecamController.instance();
             // Mark particle for immediate death if freecam is active and player's entity is at this position
+            // This prevents the particle from ever updating, avoiding per-frame allocation overhead
             if (controller.isActive() && !controller.isPlayerControlled()
                 && freecam_gtnh$isNearPlayer(position.x, position.y, position.z)) {
                 this.setDead();
-            }
-        }
-
-        @Inject(method = "onUpdate", at = @At("HEAD"), cancellable = true, remap = false)
-        private void cancelUpdateInFreecam(CallbackInfo ci) {
-            FreecamController controller = FreecamController.instance();
-            if (controller.isActive() && !controller.isPlayerControlled()) {
-                if (freecam_gtnh$isNearPlayer(this.posX, this.posY, this.posZ)) {
-                    this.setDead();
-                    ci.cancel();
-                }
             }
         }
     }
@@ -91,20 +81,10 @@ public class MixinGalaxySpaceParticles {
         private void onConstructor(World world, Vector3 position, Vector3 motion, CallbackInfo ci) {
             FreecamController controller = FreecamController.instance();
             // Mark particle for immediate death if freecam is active and player's entity is at this position
+            // This prevents the particle from ever updating, avoiding per-frame allocation overhead
             if (controller.isActive() && !controller.isPlayerControlled()
                 && freecam_gtnh$isNearPlayer(position.x, position.y, position.z)) {
                 this.setDead();
-            }
-        }
-
-        @Inject(method = "onUpdate", at = @At("HEAD"), cancellable = true, remap = false)
-        private void cancelUpdateInFreecam(CallbackInfo ci) {
-            FreecamController controller = FreecamController.instance();
-            if (controller.isActive() && !controller.isPlayerControlled()) {
-                if (freecam_gtnh$isNearPlayer(this.posX, this.posY, this.posZ)) {
-                    this.setDead();
-                    ci.cancel();
-                }
             }
         }
     }

--- a/src/main/java/com/caedis/freecam/mixins/late/galaxyspace/MixinGalaxySpaceParticles.java
+++ b/src/main/java/com/caedis/freecam/mixins/late/galaxyspace/MixinGalaxySpaceParticles.java
@@ -1,0 +1,111 @@
+package com.caedis.freecam.mixins.late.galaxyspace;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.particle.EntityFX;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.caedis.freecam.camera.FreecamController;
+
+import galaxyspace.core.particle.EntityJetpackFlameFX;
+import galaxyspace.core.particle.EntityJetpackSmokeFX;
+import micdoodle8.mods.galacticraft.api.vector.Vector3;
+
+/**
+ * Mixin to prevent GalaxySpace jetpack particles from spawning/updating during freecam. Note: GalaxySpace 1.1.139+
+ * uses Vector3 constructor instead of individual doubles.
+ */
+public class MixinGalaxySpaceParticles {
+
+    /**
+     * Mixin for jetpack flame particles
+     */
+    @Mixin(value = EntityJetpackFlameFX.class, remap = false)
+    public static abstract class MixinEntityJetpackFlameFX extends EntityFX {
+
+        // Constructor required for mixin
+        public MixinEntityJetpackFlameFX(World world, double x, double y, double z) {
+            super(world, x, y, z);
+        }
+
+        /**
+         * Check if a position is near the player (within 4 blocks)
+         */
+        @Unique
+        private boolean freecam_gtnh$isNearPlayer(double x, double y, double z) {
+            EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+            if (player == null) return false;
+            return player.getDistanceSq(x, y, z) < 16.0; // 4 blocks squared
+        }
+
+        @Inject(method = "<init>", at = @At("RETURN"), remap = false)
+        private void onConstructor(World world, Vector3 position, Vector3 motion, CallbackInfo ci) {
+            FreecamController controller = FreecamController.instance();
+            // Mark particle for immediate death if freecam is active and player's entity is at this position
+            if (controller.isActive() && !controller.isPlayerControlled()
+                && freecam_gtnh$isNearPlayer(position.x, position.y, position.z)) {
+                this.setDead();
+            }
+        }
+
+        @Inject(method = "onUpdate", at = @At("HEAD"), cancellable = true, remap = false)
+        private void cancelUpdateInFreecam(CallbackInfo ci) {
+            FreecamController controller = FreecamController.instance();
+            if (controller.isActive() && !controller.isPlayerControlled()) {
+                if (freecam_gtnh$isNearPlayer(this.posX, this.posY, this.posZ)) {
+                    this.setDead();
+                    ci.cancel();
+                }
+            }
+        }
+    }
+
+    /**
+     * Mixin for jetpack smoke particles
+     */
+    @Mixin(value = EntityJetpackSmokeFX.class, remap = false)
+    public static abstract class MixinEntityJetpackSmokeFX extends EntityFX {
+
+        // Constructor required for mixin
+        public MixinEntityJetpackSmokeFX(World world, double x, double y, double z) {
+            super(world, x, y, z);
+        }
+
+        /**
+         * Check if a position is near the player (within 4 blocks)
+         */
+        @Unique
+        private boolean freecam_gtnh$isNearPlayer(double x, double y, double z) {
+            EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+            if (player == null) return false;
+            return player.getDistanceSq(x, y, z) < 16.0; // 4 blocks squared
+        }
+
+        @Inject(method = "<init>", at = @At("RETURN"), remap = false)
+        private void onConstructor(World world, Vector3 position, Vector3 motion, CallbackInfo ci) {
+            FreecamController controller = FreecamController.instance();
+            // Mark particle for immediate death if freecam is active and player's entity is at this position
+            if (controller.isActive() && !controller.isPlayerControlled()
+                && freecam_gtnh$isNearPlayer(position.x, position.y, position.z)) {
+                this.setDead();
+            }
+        }
+
+        @Inject(method = "onUpdate", at = @At("HEAD"), cancellable = true, remap = false)
+        private void cancelUpdateInFreecam(CallbackInfo ci) {
+            FreecamController controller = FreecamController.instance();
+            if (controller.isActive() && !controller.isPlayerControlled()) {
+                if (freecam_gtnh$isNearPlayer(this.posX, this.posY, this.posZ)) {
+                    this.setDead();
+                    ci.cancel();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/caedis/freecam/mixins/late/gregtech/MixinGregTechJetpack.java
+++ b/src/main/java/com/caedis/freecam/mixins/late/gregtech/MixinGregTechJetpack.java
@@ -1,0 +1,33 @@
+package com.caedis.freecam.mixins.late.gregtech;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.caedis.freecam.camera.FreecamController;
+
+import gregtech.api.items.armor.ArmorContext;
+import gregtech.api.items.armor.behaviors.JetpackBehavior;
+
+/**
+ * Mixin to disable GregTech Mechanical Armour jetpack controls during freecam. Targets
+ * the JetpackBehavior class which handles jetpack functionality for GT armor with jetpack addons.
+ */
+@Mixin(value = JetpackBehavior.class, remap = false)
+public abstract class MixinGregTechJetpack {
+
+    /**
+     * Prevent the performFlying method from executing during freecam by canceling it at HEAD. This prevents all
+     * jetpack movement, energy drain, and particle effects when freecam is active and the camera (not the player) is
+     * being controlled.
+     */
+    @Inject(method = "performFlying", at = @At("HEAD"), cancellable = true, remap = false)
+    private void disableJetpackInFreecam(ArmorContext context, CallbackInfo ci) {
+        FreecamController controller = FreecamController.instance();
+        // Only disable jetpack when freecam is active AND camera is being controlled
+        if (controller.isActive() && !controller.isPlayerControlled()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/caedis/freecam/mixins/late/ic2/MixinIC2Keyboard.java
+++ b/src/main/java/com/caedis/freecam/mixins/late/ic2/MixinIC2Keyboard.java
@@ -1,0 +1,32 @@
+package com.caedis.freecam.mixins.late.ic2;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.caedis.freecam.camera.FreecamController;
+
+@Mixin(value = ic2.core.util.Keyboard.class, remap = false)
+public abstract class MixinIC2Keyboard {
+
+    @Inject(method = "isJumpKeyDown", at = @At("HEAD"), cancellable = true)
+    private static void disableJumpInFreecam(EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+        FreecamController controller = FreecamController.instance();
+        // Only disable jetpack jump when freecam is active AND camera is being controlled
+        if (controller.isActive() && !controller.isPlayerControlled()) {
+            cir.setReturnValue(false);
+        }
+    }
+
+    @Inject(method = "isBoostKeyDown", at = @At("HEAD"), cancellable = true)
+    private static void disableBoostInFreecam(EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+        FreecamController controller = FreecamController.instance();
+        // Only disable jetpack boost when freecam is active AND camera is being controlled
+        if (controller.isActive() && !controller.isPlayerControlled()) {
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/java/com/caedis/freecam/mixins/late/ic2/MixinIC2Keyboard.java
+++ b/src/main/java/com/caedis/freecam/mixins/late/ic2/MixinIC2Keyboard.java
@@ -4,29 +4,30 @@ import net.minecraft.entity.player.EntityPlayer;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.caedis.freecam.camera.FreecamController;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 
 @Mixin(value = ic2.core.util.Keyboard.class, remap = false)
 public abstract class MixinIC2Keyboard {
 
-    @Inject(method = "isJumpKeyDown", at = @At("HEAD"), cancellable = true)
-    private static void disableJumpInFreecam(EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+    @ModifyReturnValue(method = "isJumpKeyDown", at = @At("RETURN"))
+    private static boolean disableJumpInFreecam(boolean original, EntityPlayer player) {
         FreecamController controller = FreecamController.instance();
         // Only disable jetpack jump when freecam is active AND camera is being controlled
         if (controller.isActive() && !controller.isPlayerControlled()) {
-            cir.setReturnValue(false);
+            return false;
         }
+        return original;
     }
 
-    @Inject(method = "isBoostKeyDown", at = @At("HEAD"), cancellable = true)
-    private static void disableBoostInFreecam(EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
+    @ModifyReturnValue(method = "isBoostKeyDown", at = @At("RETURN"))
+    private static boolean disableBoostInFreecam(boolean original, EntityPlayer player) {
         FreecamController controller = FreecamController.instance();
         // Only disable jetpack boost when freecam is active AND camera is being controlled
         if (controller.isActive() && !controller.isPlayerControlled()) {
-            cir.setReturnValue(false);
+            return false;
         }
+        return original;
     }
 }

--- a/src/main/java/com/caedis/freecam/mixins/late/projectred/MixinProjectRedJetpack.java
+++ b/src/main/java/com/caedis/freecam/mixins/late/projectred/MixinProjectRedJetpack.java
@@ -1,0 +1,34 @@
+package com.caedis.freecam.mixins.late.projectred;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.caedis.freecam.camera.FreecamController;
+
+import mrtjp.projectred.expansion.ItemJetpack;
+
+/**
+ * Mixin to disable ProjectRed jetpack entirely during freecam. Cancels the entire onArmorTick method to prevent all
+ * jetpack functionality including propulsion, fuel consumption, and particle effects.
+ */
+@Mixin(value = ItemJetpack.class, remap = false)
+public abstract class MixinProjectRedJetpack {
+
+    /**
+     * Cancel the entire onArmorTick method during freecam to disable all jetpack functionality. This prevents
+     * movement, fuel consumption, particle effects, and any other jetpack behavior when the camera is being controlled.
+     */
+    @Inject(method = "onArmorTick", at = @At("HEAD"), cancellable = true, remap = false)
+    private void disableJetpackInFreecam(World world, EntityPlayer player, ItemStack stack, CallbackInfo ci) {
+        FreecamController controller = FreecamController.instance();
+        if (controller.isActive() && !controller.isPlayerControlled()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/mixins.freecam-gtnh.late.json
+++ b/src/main/resources/mixins.freecam-gtnh.late.json
@@ -4,6 +4,18 @@
   "package": "com.caedis.freecam.mixins.late",
   "refmap": "mixins.freecam-gtnh.refmap.json",
   "target": "@env(DEFAULT)",
+  "client": [
+    "galaxyspace.MixinGalaxySpaceKeyHandler$MixinItemJetPack",
+    "galaxyspace.MixinGalaxySpaceKeyHandler$MixinItemSpacesuitJetPlate",
+    "galaxyspace.MixinGalaxySpaceParticles$MixinEntityJetpackFlameFX",
+    "galaxyspace.MixinGalaxySpaceParticles$MixinEntityJetpackSmokeFX",
+    "gregtech.MixinGregTechJetpack",
+    "holoinventory.MixinRenderer",
+    "ic2.MixinIC2Keyboard",
+    "projectred.MixinProjectRedJetpack",
+    "thaumcraft.MixinRenderEventHandler",
+    "waila.MixinOverlayRenderer"
+  ],
   "compatibilityLevel": "JAVA_8",
   "mixinextras": {"minVersion": "0.5.0"}
 }


### PR DESCRIPTION
## Summary
Added Mixins to prevent jetpacks from ic2, galaxyspace, projectred and gregtech to fire when in freecam.
added lockplayer config, this will freeze any player movement while in freecam, this is basicly the same feature that modern freecam has, but its generally not recommendet in multiplayer.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
